### PR TITLE
Modify code to allow building from source on macOS

### DIFF
--- a/include/SocketRecorder.h
+++ b/include/SocketRecorder.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#ifdef __linux__ 
+#ifdef __APPLE__ || __linux__ 
 #include "SocketRecorder_linux.h"
 #elif _WIN32
 #include "SocketRecorder_win.h"

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -102,7 +102,7 @@ int ConfigParser::write(string fn)
     /// Open output file
     std::ofstream f(fn);
     if (!f.is_open()) {
-        LOG_ERR("Could not open config file %s for writing!", fn);
+        LOG_ERR("Could not open config file %s for writing!", fn.c_str());
         return -1;
     }
     
@@ -115,7 +115,7 @@ int ConfigParser::write(string fn)
         // warning: super long str vals will cause overwrite error!
         try { sprintf(tmps, "%-16s : %s\n", it.first.c_str(), it.second.c_str()); }
         catch (std::exception& e) {
-			LOG_ERR("Error writing key/value pair (%s : %s)! Error was: %s", it.first, it.second, e.what());
+			LOG_ERR("Error writing key/value pair (%s : %s)! Error was: %s", it.first.c_str(), it.second.c_str(), e.what());
             f.close();
             return -1;
         }
@@ -331,5 +331,5 @@ void ConfigParser::printAll()
     for (auto& it : _data) {
         s << "\t" << it.first << "\t: " << it.second << std::endl;
     }
-    LOG_DBG("%s", s.str());
+    LOG_DBG("%s", s.str().c_str());
 }

--- a/src/SocketRecorder.cpp
+++ b/src/SocketRecorder.cpp
@@ -4,7 +4,7 @@
 /// \author     Richard Moore
 /// \copyright  CC BY-NC-SA 3.0
 
-#ifdef __linux__ 
+#ifdef __APPLE__ || __linux__
 #include "SocketRecorder_linux.src"
 #elif _WIN32
 #include "SocketRecorder_win.src"


### PR DESCRIPTION
Code was not checking for __APPLE__, only for __linux__ and _WIN32. This commit fixes that.
Additionally, fixes the problem of non-trivial object types being passed to LOG functions.