### PR TITLE
Fixing build error. Sleep function ambigous

### DIFF
--- a/exec/fictrac.cpp
+++ b/exec/fictrac.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
         if (!_active) {
             tracker->terminate();
         }
-        sleep(250);
+        ficsleep(250);
     }
 
     /// Save the eventual template to disk.
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     tracker.reset();
 
     /// Wait a bit before exiting...
-    sleep(250);
+    ficsleep(250);
 
     //PRINT("\n\nHit ENTER to exit..");
     //getchar_clean();

--- a/include/timing.h
+++ b/include/timing.h
@@ -99,7 +99,7 @@ static std::string dateString()
 ///
 /// Sleep (ms)
 ///
-static void sleep(long ms)
+static void ficsleep(long ms)
 {
 	std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }

--- a/src/CVSource.cpp
+++ b/src/CVSource.cpp
@@ -194,7 +194,7 @@ bool CVSource::grab(cv::Mat& frame)
         static double sleep_ms = 1000/_fps;
         av_fps = 0.15 * av_fps + 0.85 * (1000 / (ts - prev_ts));
         sleep_ms *= 0.25 * (av_fps / _fps) + 0.75;
-        sleep(static_cast<long>(round(sleep_ms)));
+        ficsleep(static_cast<long>(round(sleep_ms)));
         prev_ts = ts;
     }
 


### PR DESCRIPTION
I don't know C++, but the build of fictrac was failing for me with the error above. I figured the function "sleep" now exists among some of the includes of the fictrac and is creating a conflict. Changing it here, as well as in timing.h and CVSource.cpp solved the issue for me.
